### PR TITLE
Simplified Image Upload

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -181,6 +181,12 @@ class Tax_Meta_Class {
       wp_enqueue_script( 'tax-meta-clss', $plugin_path . '/js/tax-meta-clss.js', array( 'jquery' ), null, true );
     
     }
+
+    if(isset($_GET['tax_meta_c'])){
+      // if uploading a file
+      wp_enqueue_script( 'tax-meta-clss', $plugin_path . '/js/media-upload.js', array( 'jquery' ), null, true );
+      wp_enqueue_style( 'tax-meta-clss', $plugin_path . '/css/media-upload.css' );
+    }
     
   }
   

--- a/Tax-meta-class/css/media-upload.css
+++ b/Tax-meta-class/css/media-upload.css
@@ -1,0 +1,41 @@
+#media-upload-header #sidemenu li#tab-type_url,
+#media-upload-header #sidemenu li#tab-gallery, 
+#media-items .media-item table.slidetoggle,
+#media-items .media-item a.toggle {
+  display: none !important;
+}
+
+#media-items .media-item {
+  min-height: 68px;
+}
+
+#media-items .media-item .acf-checkbox {
+  float: left;
+  margin: 28px 10px 0;
+}
+
+#media-items .media-item .pinkynail {
+  max-width: 64px;
+  max-height: 64px;
+  display: block !important;
+}
+
+#media-items .media-item .filename.new {
+  min-height: 0;
+  padding: 25px 10px 10px;
+  line-height: 14px;
+  
+}
+
+#media-items .media-item .title {
+  line-height: 14px;
+}
+
+#media-items .media-item .button {
+  float: right;
+  margin: -2px 0 0 10px;
+}
+
+#media-upload .ml-submit {
+  display: none !important;
+}

--- a/Tax-meta-class/js/media-upload.js
+++ b/Tax-meta-class/js/media-upload.js
@@ -1,0 +1,40 @@
+(function($){ 
+  // detect when a image has been added to list after upload
+  function tmc_add_buttons()
+  {
+    // add buttons to media items
+    $('#media-items .media-item:not(.tmc-active)').each(function(){     
+
+      // needs attachment ID
+      if($(this).children('input[id*="type-of-"]').length == 0){ return false; }
+      
+      // only once!
+      $(this).addClass('tmc-active');
+      
+      // find id
+      var id = $(this).children('input[id*="type-of-"]').attr('id').replace('type-of-', '');
+      
+      var link = $('<a href="#" class="button tmc-select">Select Image</a>');
+      link.click(function(){
+        $('input[name="send[' + id + ']"]').click();
+        return false;
+      });
+
+      // change text of insert button, and add new button
+      $(this).find('.filename.new').append(link);
+    });
+  }
+  
+  // run the tmc_add_buttons ever 500ms when on the image upload tab
+  var acf_t = setInterval(function(){
+    tmc_add_buttons();
+  }, 500);
+  
+  // add input filters to allow for tab navigation
+  $(document).ready(function(){  
+    setTimeout(function(){
+      tmc_add_buttons();
+    }, 1);
+  });
+        
+})(jQuery);


### PR DESCRIPTION
I liked the way that the ACF plugin allows users to upload then "select" the image rather than deal with the default complex image options, so i pulled some of its code into this plugin. This could probably be tweaked to be configurable but figure I'd through it out there. Perhaps this would be better suited for its own plugin?
