### PR TITLE
== typo

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -110,9 +110,9 @@ class Tax_Meta_Class {
     $this->_Local_images = (isset($meta_box['local_images'])) ? true : false;
     $this->add_missed_values();
     if (isset($meta_box['use_with_theme']))
-      if ($meta_box['use_with_theme'] == true){
+      if ($meta_box['use_with_theme'] === true){
         $this->SelfPath = get_template_directory_uri() . '/Tax-meta-class';
-      }elseif($meta_box['use_with_theme'] == false){
+      }elseif($meta_box['use_with_theme'] === false){
         $this->SelfPath = plugins_url( 'Tax-meta-class', plugin_basename( dirname( __FILE__ ) ) );
       }else{
         $this->SelfPath = $meta_box['use_with_theme'];


### PR DESCRIPTION
== string returns true, therefore custom path can't be set
