### PR TITLE
Make has_field() check inside repeater fields.

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -527,7 +527,9 @@ class Tax_Meta_Class {
       if (count($meta) > 0 && is_array($meta) ){
          foreach ($meta as $me){
            //for labling toggles
-           $mmm =  $me[$field['fields'][0]['id']];
+           if($me[$field]) {
+              $mmm =  $me[$field['fields'][0]['id']];           
+           } 
            echo '<div class="at-repater-block">'.$mmm.'<br/><table class="repeater-table" style="display: none;">';
            if ($field['inline']){
              echo '<tr class="at-inline" VALIGN="top">';


### PR DESCRIPTION
Ran into a problem when I had a repeater field with an image, but no images called above. In this case has_field() wouldn't enqueue the necessary scripts so it's important to make sure the function checks inside of repeater fields as well.
