### PR TITLE
make child theme compatible

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -111,7 +111,7 @@ class Tax_Meta_Class {
     $this->add_missed_values();
     if (isset($meta_box['use_with_theme'])){
       if ($meta_box['use_with_theme'] === true){
-        $this->SelfPath = get_template_directory_uri() . '/Tax-meta-class';
+        $this->SelfPath = get_stylesheet_directory_uri() . '/Tax-meta-class';
       }elseif($meta_box['use_with_theme'] === false){
         $this->SelfPath = plugins_url( 'Tax-meta-class', plugin_basename( dirname( __FILE__ ) ) );
       }else{


### PR DESCRIPTION
get_template_directory_uri() isn't child theme friendly, use  get_stylesheet_directory_uri() instead.

http://codex.wordpress.org/Function_Reference/get_template_directory_uri
