### PR TITLE
Fixed problem when You use class in your plugin

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -113,7 +113,7 @@ class Tax_Meta_Class {
       if ($meta_box['use_with_theme'] === true){
         $this->SelfPath = get_template_directory_uri() . '/Tax-meta-class';
       }elseif($meta_box['use_with_theme'] === false){
-        $this->SelfPath = plugins_url( 'Tax-meta-class', plugin_basename( dirname( __FILE__ ) ) );
+        $this->SelfPath = plugins_url( plugin_basename( dirname( __FILE__ ) ) );
       }else{
         $this->SelfPath = $meta_box['use_with_theme'];
       }


### PR DESCRIPTION
When You use class with a different dirname of 'Tax-meta-class' static files are not loaded. See #71
