### PR TITLE
Fix show_field_end closing tag

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -715,9 +715,9 @@ class Tax_Meta_Class {
         echo "<div class='desc-field'>{$field['desc']}</div>";
       }
       if ($this->_form_type == 'edit'){
-        echo '<td>';  
+        echo '</td>';  
       }else{
-        echo '<td></div>';
+        echo '</td></div>';
       }
     }
   }


### PR DESCRIPTION
The td on fields was not being closed, causing some JS issues with another plugin. This patches that up!
