### PR TITLE
Fix wpColorPicker Error

### DIFF
--- a/Tax-meta-class/js/tax-meta-clss.js
+++ b/Tax-meta-class/js/tax-meta-clss.js
@@ -60,7 +60,11 @@ function update_repeater_fields(){
      *
      * @since 2.1.1
      */
-    $('.at-color').wpColorPicker();
+    $('.at-color').each( function( index, dom ){      
+
+      $( dom ).wpColorPicker();
+    });
+
   
     /**
      * Delete File.
@@ -154,7 +158,10 @@ jQuery(document).ready(function($) {
     
   });
 
-  $('.at-color').wpColorPicker();
+  $('.at-color').each( function( index, dom ){
+    
+    $( dom ).wpColorPicker();
+  });
 
   /**
    * Helper Function


### PR DESCRIPTION
**BACKGROUND**
1. The main JS file always calls `$('.at-color')wpColorPicker()` even if the user never instantiated a color field.
2. The class only enqueues `wp-color-picker` lib only if the user instantiates a color field.

**PROBLEM**
If the user doesn't have a color field, the main js file will always fail. 

**SOLUTION**
Don't call `wpColorPicker()` unless a color field is detected in the dom. If a color field was created using the api, there should be a color field in the DOM and `wp-color-picker` would be instantiated by the class.