### PR TITLE
Fixed a bug with delete_term_meta API (meta name was required)

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -1707,7 +1707,8 @@ class Tax_Meta_Class {
   public function delete_taxonomy_metadata($term,$term_id) {
     delete_option( 'tax_meta_'.$term_id );
     if ( function_exists( 'delete_term_meta') ){
-      delete_term_meta( $term_id );
+      foreach( $this->_fields as $field )
+        delete_term_meta( $term_id, $field );
     }
   }
 


### PR DESCRIPTION
Simple iterate over each field to delete each term individually.