### PR TITLE
fix js wpColorPicker error 

### DIFF
--- a/Tax-meta-class/js/tax-meta-clss.js
+++ b/Tax-meta-class/js/tax-meta-clss.js
@@ -60,7 +60,9 @@ function update_repeater_fields(){
      *
      * @since 2.1.1
      */
-    $('.at-color').wpColorPicker();
+    if (($.isFunction($.fn.wpColorPicker))) { 
+      $('.at-color').wpColorPicker();
+    }  
   
     /**
      * Delete File.


### PR DESCRIPTION
when there is no ColorPicker field exist, it causes js error on console. so it stops other js run (image picker, file picker,...)