### PR TITLE
Added meta key name for delete_term_meta()

### DIFF
--- a/Tax-meta-class/Tax-meta-class.php
+++ b/Tax-meta-class/Tax-meta-class.php
@@ -1707,7 +1707,9 @@ class Tax_Meta_Class {
   public function delete_taxonomy_metadata($term,$term_id) {
     delete_option( 'tax_meta_'.$term_id );
     if ( function_exists( 'delete_term_meta') ){
-      delete_term_meta( $term_id );
+      $name = 'tax_meta_' . $term_id ;
+	    
+      delete_term_meta( $term_id, $name );
     }
   }
 


### PR DESCRIPTION
The meta key parameter is required.
https://developer.wordpress.org/reference/functions/delete_term_meta/